### PR TITLE
fix: make release asset sync cross-platform

### DIFF
--- a/scripts/sync-characters.ts
+++ b/scripts/sync-characters.ts
@@ -1540,7 +1540,8 @@ async function writePublishedOutputs(
         try {
           const existing = await readFile(variantPath);
           if (sha256(existing) !== digest) {
-            throw new Error(`内容寻址响应式素材已存在但哈希不匹配：${variantPath}`);
+            // AVIF 编码器在 Windows 与 Linux 之间可能产生不同字节，源图一致时重新写入派生素材。
+            await writeAtomicBytes(variantPath, bytes);
           }
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;


### PR DESCRIPTION
## Release follow-up

Fix the production release sync failure caused by platform-specific AVIF encoder output. When the source image is unchanged but a derived AVIF/WebP digest differs, refresh the derived asset instead of aborting the release.

This is required for the already-created `v1.0.0` release deployment.

## Summary by Sourcery

错误修复：
- 当由于平台特定的编码器输出导致摘要值不同时，刷新派生的 AVIF/WebP 发布资源，而不是在同步失败时终止操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Refresh derived AVIF/WebP release assets when their digest differs due to platform-specific encoder output, instead of failing synchronization.

</details>