### PR TITLE
fix: correct currency wars pool and weekly handoff

### DIFF
--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -494,7 +494,7 @@ describe("服务端游戏裁决", () => {
     expect(create.status).toBe(400);
   });
 
-  it("币战复盘使用绑定候选池精确计数，且不泄露羁绊名称", async () => {
+  it("币战复盘使用绑定候选池精确计数，且不标记具体共享羁绊", async () => {
     const { cookie } = await createSession();
     const playable = await dataOf<PublicGame>(
       await SELF.fetch("https://fireflydle.games/api/games", {
@@ -529,7 +529,10 @@ describe("服务端游戏裁决", () => {
     expect(finished.status).toBe("won");
     expect(finished.inferenceReview?.initialCandidates).toBe(candidateCount);
     expect(finished.inferenceReview?.steps[0]?.remainingCandidates).toBe(1);
-    expect(JSON.stringify(finished)).not.toMatch(/ipc|merchant|herta/);
+    expect(finished.guesses[0]?.character).toHaveProperty("synergies");
+    expect(
+      finished.guesses[0]?.cells.find((cell) => cell.field === "synergies"),
+    ).not.toHaveProperty("matchedSynergy");
     const replay = await dataOf<{ game: PublicGame }>(
       await SELF.fetch(`https://fireflydle.games/api/replays/${game.id}`, { headers: { cookie } }),
     );

--- a/apps/api/test/friend-challenge.test.ts
+++ b/apps/api/test/friend-challenge.test.ts
@@ -394,7 +394,7 @@ describe("特殊模式好友挑战", () => {
         expect(
           Boolean(privateSnapshot.currencyWarsUnits?.some((unit) => unit.synergies?.length)),
         ).toBe(true);
-        expect(completed.guesses[0]?.character).not.toHaveProperty("synergies");
+        expect(completed.guesses[0]?.character).toHaveProperty("synergies");
         expect(completed.answer).not.toHaveProperty("synergies");
         expect(candidatesText).not.toMatch(/stellaron-hunters|astral-express|masked-fools/);
       }

--- a/apps/api/test/game-snapshot.test.ts
+++ b/apps/api/test/game-snapshot.test.ts
@@ -132,7 +132,7 @@ async function createSession(): Promise<string> {
 }
 
 describe("单人模式快照迁移", () => {
-  it("货币战争使用独立单位子池并且公开响应不泄露羁绊关系", async () => {
+  it("货币战争猜前隐藏羁绊，猜后只返回已猜单位自身羁绊", async () => {
     const cookie = await createSession();
     const created = await dataOf<PublicGame>(
       await SELF.fetch("https://fireflydle.games/api/games", {
@@ -164,8 +164,13 @@ describe("单人模式快照迁移", () => {
       "position",
       "synergies",
     ]);
-    expect(JSON.stringify(guessed)).not.toContain("stellaron-hunters");
-    expect(guessed.guesses[0]?.character).not.toHaveProperty("synergies");
+    expect(guessed.guesses[0]?.character).toHaveProperty("synergies", [
+      "break",
+      "stellaron-hunters",
+    ]);
+    expect(guessed.guesses[0]?.cells.find((cell) => cell.field === "synergies")).not.toHaveProperty(
+      "matchedSynergy",
+    );
   });
 
   it("创建和恢复返回统一模式活动元数据且进行中不泄露答案", async () => {

--- a/apps/web/src/features/game/GamePage.tsx
+++ b/apps/web/src/features/game/GamePage.tsx
@@ -889,6 +889,7 @@ function ActiveGame({
                 guesses={game.guesses}
                 locale={locale}
                 fields={game.fieldDefinitions}
+                synergyDefinitions={modeManifest.currencyWars?.synergyDefinitions}
                 animateLatest={contentModeId === "playable"}
               />
             </>

--- a/apps/web/src/features/game/GuessBoard.test.tsx
+++ b/apps/web/src/features/game/GuessBoard.test.tsx
@@ -129,6 +129,56 @@ describe("动态 GuessBoard", () => {
     expect(markup).not.toContain('aria-label="属性: 火');
   });
 
+  test("币战显示已猜单位全部羁绊名，但不标记具体共享项", () => {
+    const currencyGuess: GuessResult = {
+      character: {
+        id: "cw-firefly",
+        names: { "zh-CN": "流萤", en: "Firefly", ja: "ホタル" },
+        aliases: { "zh-CN": [], en: [], ja: [] },
+        cost: 4,
+        position: "front",
+        synergies: ["break", "stellaron-hunters"],
+        assets: {
+          avatarPath: "/characters/firefly.webp",
+          portraitPath: "/characters/firefly.webp",
+          sha256: "b".repeat(64),
+          rightsNotice: "仅用于测试",
+        },
+      },
+      cells: [{ field: "synergies", state: "close", direction: "none" }],
+      isCorrect: false,
+      guessedAt: "2026-08-18T00:00:00.000Z",
+    };
+    const synergyField: FieldDefinition = {
+      id: "synergies",
+      label: { "zh-CN": "原生羁绊", en: "Native Synergies", ja: "固有シナジー" },
+      valueType: "set",
+      comparison: "set",
+      required: true,
+    };
+    const markup = renderToStaticMarkup(
+      <GuessBoard
+        guesses={[currencyGuess]}
+        locale="zh-CN"
+        fields={[synergyField]}
+        synergyDefinitions={[
+          {
+            id: "break",
+            names: { "zh-CN": "击破", en: "Break Effect", ja: "撃破" },
+          },
+          {
+            id: "stellaron-hunters",
+            names: { "zh-CN": "星核猎手", en: "Stellaron Hunter", ja: "星核ハンター" },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("击破 · 星核猎手");
+    expect(markup).toContain('aria-label="原生羁绊: 击破 · 星核猎手; 接近"');
+    expect(markup).not.toContain("matchedSynergy");
+  });
+
   test("旧多人结果缺少字段定义时使用普通角色六列兼容规则", () => {
     const markup = renderToStaticMarkup(<GuessBoard guesses={[]} locale="zh-CN" />);
 

--- a/apps/web/src/features/game/GuessBoard.tsx
+++ b/apps/web/src/features/game/GuessBoard.tsx
@@ -1,6 +1,12 @@
 import { ArrowDown, ArrowUp, Check, CircleDot, CloudFog, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { FieldDefinition, GuessCell, GuessResult, Locale } from "@fireflydle/contracts";
+import type {
+  FieldDefinition,
+  GuessCell,
+  GuessResult,
+  Locale,
+  LocalizedText,
+} from "@fireflydle/contracts";
 import {
   contentManifest,
   elementLabels,
@@ -24,7 +30,12 @@ function StatusIcon({ cell }: { cell: GuessCell }) {
   return <X size={16} aria-hidden="true" />;
 }
 
-function cellValue(guess: GuessResult, field: string, locale: Locale): string {
+function cellValue(
+  guess: GuessResult,
+  field: string,
+  locale: Locale,
+  synergyNames: ReadonlyMap<string, LocalizedText>,
+): string {
   switch (field) {
     case "cost":
       return "cost" in guess.character ? String(guess.character.cost) : "—";
@@ -36,8 +47,12 @@ function cellValue(guess: GuessResult, field: string, locale: Locale): string {
         "front-back": locale === "zh-CN" ? "前后台" : locale === "ja" ? "前後" : "Front / back",
       }[guess.character.position];
     }
-    case "synergies":
-      return "—";
+    case "synergies": {
+      if (!("synergies" in guess.character) || !guess.character.synergies) return "—";
+      return guess.character.synergies
+        .map((synergyId) => synergyNames.get(synergyId)?.[locale] ?? synergyId)
+        .join(" · ");
+    }
     case "element":
       return "element" in guess.character ? elementLabels[guess.character.element][locale] : "—";
     case "path":
@@ -71,14 +86,19 @@ export function GuessBoard({
   guesses,
   locale,
   fields,
+  synergyDefinitions = [],
   animateLatest = false,
 }: {
   guesses: readonly GuessResult[];
   locale: Locale;
   fields?: readonly FieldDefinition[] | undefined;
+  synergyDefinitions?: readonly { id: string; names: LocalizedText }[] | undefined;
   animateLatest?: boolean;
 }) {
   const { t } = useTranslation();
+  const synergyNames = new Map(
+    synergyDefinitions.map((definition) => [definition.id, definition.names]),
+  );
   const definitions = fields ?? legacyFields;
   const observedFields = new Set(guesses.flatMap((guess) => guess.cells.map((cell) => cell.field)));
   const visibleFields =
@@ -124,7 +144,10 @@ export function GuessBoard({
                         direction: "none",
                       } satisfies GuessCell);
                     const direction = directionLabel(status, t);
-                    const value = status.state === "fog" ? "?" : cellValue(guess, field.id, locale);
+                    const value =
+                      status.state === "fog"
+                        ? "?"
+                        : cellValue(guess, field.id, locale, synergyNames);
                     return (
                       <td
                         key={field.id}

--- a/apps/web/src/features/weekly/WeeklyPage.test.ts
+++ b/apps/web/src/features/weekly/WeeklyPage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { weeklyModeLabel, weeklyModePath } from "./WeeklyPage";
+import type { WeeklyRun } from "@fireflydle/contracts";
+import { getWeeklyRoundTransition, weeklyModeLabel, weeklyModePath } from "./WeeklyPage";
 
 describe("三种模式周赛入口", () => {
   it.each([
@@ -9,5 +10,28 @@ describe("三种模式周赛入口", () => {
   ] as const)("%s 保留 modeId 路径契约", (modeId, path, label) => {
     expect(weeklyModePath(modeId)).toBe(path);
     expect(weeklyModeLabel(modeId, "zh-CN")).toBe(label);
+  });
+});
+
+describe("周赛题间过渡", () => {
+  const run = (gameId: string, gameCount: number, status: WeeklyRun["status"] = "active") =>
+    ({
+      status,
+      games: Array.from({ length: gameCount }, (_, index) => ({
+        id: index === gameCount - 1 ? gameId : `finished-${index}`,
+      })),
+      currentGame: status === "active" ? { id: gameId } : null,
+    }) as WeeklyRun;
+
+  it("服务端切换到下一题时生成明确题间状态", () => {
+    expect(getWeeklyRoundTransition(run("game-1", 1), run("game-2", 2))).toEqual({
+      completedQuestion: 1,
+      nextQuestion: 2,
+    });
+  });
+
+  it("同一题更新或周赛完成时不插入过渡", () => {
+    expect(getWeeklyRoundTransition(run("game-1", 1), run("game-1", 1))).toBeNull();
+    expect(getWeeklyRoundTransition(run("game-5", 5), run("game-5", 5, "completed"))).toBeNull();
   });
 });

--- a/apps/web/src/features/weekly/WeeklyPage.tsx
+++ b/apps/web/src/features/weekly/WeeklyPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Flag, LoaderCircle, Trophy } from "lucide-react";
+import { ArrowLeft, ArrowRight, Flag, LoaderCircle, Trophy } from "lucide-react";
 import { Link } from "react-router-dom";
 import type {
   ContentModeId,
@@ -12,6 +12,7 @@ import {
   aeonEntities,
   characters,
   contentManifest,
+  currencyWarsRuleset,
   currencyWarsUnitSummaries,
   npcEntities,
   npcSummary,
@@ -41,6 +42,30 @@ export function weeklyModeLabel(modeId: ContentModeId, locale: Locale): string {
   return modeLabels[modeId][locale];
 }
 
+export interface WeeklyRoundTransition {
+  completedQuestion: number;
+  nextQuestion: number;
+}
+
+export function getWeeklyRoundTransition(
+  previous: WeeklyRun | null | undefined,
+  next: WeeklyRun,
+): WeeklyRoundTransition | null {
+  if (
+    previous?.status !== "active" ||
+    next.status !== "active" ||
+    !previous.currentGame ||
+    !next.currentGame ||
+    previous.currentGame.id === next.currentGame.id
+  ) {
+    return null;
+  }
+  return {
+    completedQuestion: previous.games.length,
+    nextQuestion: next.games.length,
+  };
+}
+
 function formatTime(milliseconds: number): string {
   const total = Math.max(0, Math.floor(milliseconds / 1000));
   const minutes = Math.floor(total / 60);
@@ -59,6 +84,8 @@ export default function WeeklyPage({ routeModeId }: { routeModeId: ContentModeId
   const session = useSession();
   const queryClient = useQueryClient();
   const [now, setNow] = useState(Date.now());
+  const [roundTransition, setRoundTransition] = useState<WeeklyRoundTransition | null>(null);
+  const roundHeadingRef = useRef<HTMLHeadingElement>(null);
   const currentModeId = getWeeklyModeId(now);
   const weekKey = getBeijingWeekKey(now);
   const current = useQuery({
@@ -81,7 +108,19 @@ export default function WeeklyPage({ routeModeId }: { routeModeId: ContentModeId
     return () => window.clearInterval(timer);
   }, []);
 
+  useEffect(() => {
+    if (!roundTransition) return;
+    const timer = window.setTimeout(() => setRoundTransition(null), 900);
+    return () => window.clearTimeout(timer);
+  }, [roundTransition]);
+
+  useEffect(() => {
+    if (!roundTransition) roundHeadingRef.current?.focus();
+  }, [roundTransition]);
+
   const applyRun = (run: WeeklyRun) => {
+    const previous = queryClient.getQueryData<WeeklyRun>(["weekly", "current"]);
+    setRoundTransition(getWeeklyRoundTransition(previous, run));
     queryClient.setQueryData(["weekly", "current"], run);
     if (run.status === "completed") {
       void queryClient.invalidateQueries({ queryKey: ["leaderboard", "weekly", run.weekKey] });
@@ -132,7 +171,7 @@ export default function WeeklyPage({ routeModeId }: { routeModeId: ContentModeId
   const game = run?.currentGame ?? null;
   const roster = rosterFor(routeModeId);
   const guessedIds = new Set(game?.guesses.map((entry) => entry.character.id) ?? []);
-  const busy = start.isPending || guess.isPending || forfeit.isPending;
+  const busy = start.isPending || guess.isPending || forfeit.isPending || roundTransition !== null;
   const error = start.error ?? guess.error ?? forfeit.error ?? current.error;
   const errorCode = error instanceof ApiClientError ? error.code : error ? "INTERNAL_ERROR" : null;
   const elapsed = run
@@ -207,12 +246,24 @@ export default function WeeklyPage({ routeModeId }: { routeModeId: ContentModeId
                 查看统一排名
               </a>
             </section>
+          ) : roundTransition ? (
+            <section className="weekly-round-transition" role="status" aria-live="assertive">
+              <span>QUESTION {roundTransition.completedQuestion} COMPLETE</span>
+              <h2>第 {roundTransition.completedQuestion} 题已记录</h2>
+              <div aria-hidden="true">
+                <ArrowRight size={20} />
+                <LoaderCircle className="weekly-spinner" size={22} />
+              </div>
+              <p>正在进入第 {roundTransition.nextQuestion} 题</p>
+            </section>
           ) : game ? (
-            <section className="weekly-game">
+            <section className="weekly-game" aria-labelledby="weekly-round-title">
               <div className="weekly-round-heading">
                 <div>
                   <span>QUESTION {run.games.length} / 5</span>
-                  <h2>锁定答案</h2>
+                  <h2 id="weekly-round-title" ref={roundHeadingRef} tabIndex={-1}>
+                    锁定答案
+                  </h2>
                 </div>
                 <button
                   className="weekly-forfeit"
@@ -248,7 +299,16 @@ export default function WeeklyPage({ routeModeId }: { routeModeId: ContentModeId
                 onSubmit={(id) => guess.mutate(id)}
               />
               {routeModeId !== "aeon" ? (
-                <GuessBoard guesses={game.guesses} locale={locale} fields={game.fieldDefinitions} />
+                <GuessBoard
+                  guesses={game.guesses}
+                  locale={locale}
+                  fields={game.fieldDefinitions}
+                  synergyDefinitions={
+                    routeModeId === "currency-wars"
+                      ? currencyWarsRuleset.synergyDefinitions
+                      : undefined
+                  }
+                />
               ) : null}
             </section>
           ) : null}

--- a/apps/web/src/features/weekly/weekly.css
+++ b/apps/web/src/features/weekly/weekly.css
@@ -82,6 +82,34 @@
 .weekly-game {
   padding-top: 34px;
 }
+.weekly-round-transition {
+  display: grid;
+  min-height: 320px;
+  place-content: center;
+  justify-items: center;
+  padding: 42px 20px;
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+}
+.weekly-round-transition > span {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+}
+.weekly-round-transition h2 {
+  margin: 12px 0 20px;
+  font-size: 1.8rem;
+}
+.weekly-round-transition > div {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  color: var(--gold);
+}
+.weekly-round-transition p {
+  margin: 14px 0 0;
+  color: var(--text-muted);
+}
 .weekly-round-heading {
   display: flex;
   align-items: end;
@@ -190,6 +218,12 @@
 @keyframes weekly-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .weekly-spinner {
+    animation: none;
   }
 }
 

--- a/apps/web/src/offline/special-mode-pack.ts
+++ b/apps/web/src/offline/special-mode-pack.ts
@@ -10,7 +10,7 @@ export interface SpecialModePackDefinition {
 
 const CACHE_PREFIX = "fireflydle-mode-";
 const PACK_VERSIONS: Record<SpecialModeId, string> = {
-  "currency-wars": "1.1.0",
+  "currency-wars": "1.1.1",
   aeon: "1.0.1",
 };
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -192,6 +192,10 @@ export const CurrencyWarsUnitSummarySchema = z.strictObject({
   aliases: LocalizedAliasesSchema,
   cost: CurrencyWarsCostSchema,
   position: z.enum(["front", "back", "front-back"]),
+  synergies: z
+    .array(z.string().regex(/^[a-z0-9][a-z0-9-]*$/))
+    .min(1)
+    .optional(),
   assets: CurrencyWarsAssetSchema,
 });
 export type CurrencyWarsUnitSummary = z.infer<typeof CurrencyWarsUnitSummarySchema>;

--- a/packages/game-data/src/data/currency-wars-manifest.json
+++ b/packages/game-data/src/data/currency-wars-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifestVersion": "1.1.0",
+  "manifestVersion": "1.1.1",
   "generatedAt": "2026-08-18T00:00:00.000Z",
   "modes": [
     {
@@ -112,7 +112,6 @@
         "cw-boothill",
         "cw-luocha",
         "cw-saber",
-        "cw-acheron",
         "cw-seele",
         "cw-sunday",
         "cw-natasha",
@@ -186,7 +185,6 @@
         "cw-boothill",
         "cw-luocha",
         "cw-saber",
-        "cw-acheron",
         "cw-seele",
         "cw-sunday",
         "cw-natasha",
@@ -264,7 +262,6 @@
         "cw-boothill",
         "cw-luocha",
         "cw-saber",
-        "cw-acheron",
         "cw-seele",
         "cw-sunday",
         "cw-natasha",
@@ -338,7 +335,6 @@
         "cw-boothill",
         "cw-luocha",
         "cw-saber",
-        "cw-acheron",
         "cw-seele",
         "cw-sunday",
         "cw-natasha",
@@ -1633,33 +1629,6 @@
           "avatarPath": "/assets/characters/saber-avatar-7dde152ddf96.png",
           "portraitPath": "/assets/characters/saber-avatar-7dde152ddf96.png",
           "sha256": "7dde152ddf963a9ba180e4ebdd5c28cd95e3aea11f2562ce1f65af6a2d59e6c1",
-          "rightsNotice": "仅用于游戏内题目展示"
-        }
-      },
-      {
-        "id": "cw-acheron",
-        "names": {
-          "zh-CN": "黄泉",
-          "en": "Acheron",
-          "ja": "黄泉"
-        },
-        "aliases": {
-          "zh-CN": ["huang quan", "huangquan"],
-          "en": ["acheron"],
-          "ja": ["yomi"]
-        },
-        "source": {
-          "url": "https://wiki.biligame.com/sr/%E8%A7%92%E8%89%B2%E4%B8%80%E8%A7%88%EF%BC%88%E8%B4%A7%E5%B8%81%EF%BC%89",
-          "revision": "bwiki-currency-roster-2026-08-18"
-        },
-        "reviewStatus": "approved",
-        "cost": 3,
-        "position": "front",
-        "synergies": ["debuff", "galaxy-rangers"],
-        "assets": {
-          "avatarPath": "/assets/characters/acheron-avatar-7676548cd1fd.png",
-          "portraitPath": "/assets/characters/acheron-avatar-7676548cd1fd.png",
-          "sha256": "7676548cd1fdb7cf3b53888c138bbbbdcbd703baeb8f884ba24bfcbe1dcb0919",
           "rightsNotice": "仅用于游戏内题目展示"
         }
       },

--- a/packages/game-data/src/index.test.ts
+++ b/packages/game-data/src/index.test.ts
@@ -100,7 +100,9 @@ describe("货币战争独立规则集", () => {
     expect(mode?.maxAttempts).toBe(6);
     expect(mode?.fields.map((field) => field.id)).toEqual(["cost", "position", "synergies"]);
     expect(candidatePool?.candidateIds.length).toBe(targetPool?.targetIds.length ?? 0);
-    expect(candidatePool?.candidateIds.length).toBe(72);
+    expect(candidatePool?.candidateIds.length).toBe(71);
+    expect(candidatePool?.candidateIds).not.toContain("cw-acheron");
+    expect(currencyWarsRuleset.units.some((unit) => unit.id === "cw-acheron")).toBeFalse();
     expect(currencyWarsRuleset.units.every((unit) => unit.id.startsWith("cw-"))).toBeTrue();
     expect(
       currencyWarsRuleset.units.find((unit) => unit.id === "cw-silver-wolf-lv-999")?.cost,

--- a/packages/game-engine/src/index.test.ts
+++ b/packages/game-engine/src/index.test.ts
@@ -129,10 +129,20 @@ describe("货币战争三列黄金判题", () => {
     ]);
   });
 
-  test("公开结果不含羁绊名称、数量或关系 ID", () => {
-    const result = createCurrencyWarsGuessResult(unit(), unit({ id: "cw-beta" }));
-    expect(result.character).not.toHaveProperty("synergies");
-    expect(JSON.stringify(result)).not.toContain("merchant");
+  test("公开结果只携带已猜单位的羁绊，不标记具体共享项", () => {
+    const result = createCurrencyWarsGuessResult(
+      unit(),
+      unit({ id: "cw-beta", synergies: ["merchant", "herta"] }),
+    );
+    expect(result.character).toHaveProperty("synergies", ["merchant", "herta"]);
+    expect(result.cells.find((cell) => cell.field === "synergies")).toEqual({
+      field: "synergies",
+      state: "close",
+      direction: "none",
+    });
+    expect(result.cells.find((cell) => cell.field === "synergies")).not.toHaveProperty(
+      "matchedSynergy",
+    );
     expect(JSON.stringify(result)).not.toContain("ipc");
   });
 

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -149,6 +149,7 @@ export function createCurrencyWarsGuessResult(
     aliases: guess.aliases,
     cost: guess.cost,
     position: guess.position,
+    synergies: guess.synergies,
     assets: guess.assets,
   });
   return {


### PR DESCRIPTION
## Summary\n- remove Acheron from the official Currency Wars pool and bump the offline pack to manifest 1.1.1\n- show the guessed unit's own synergy names while keeping shared-synergy feedback anonymous\n- add an explicit weekly question handoff state and temporarily lock input while the next question loads\n\n## Validation\n- API tests: 49 passed\n- game-data and game-engine tests: 57 passed\n- web tests: 16 passed\n- package typechecks passed\n- changed-file Prettier checks passed

## Summary by Sourcery

校正 Currency Wars 池数据和反馈隐私，同时让每周问题的交接过程更明确并确保输入安全。

Bug Fixes:
- 将 Acheron 从官方的 Currency Wars 单位池中移除，并将离线模式包更新到 manifest 版本 1.1.1。
- 在保持共享协同效果匹配匿名的前提下，暴露被猜测的 Currency Wars 单位自身的协同效果名称。
- 在每周问题之间增加一个显式的过渡状态，并在下一个问题加载期间暂时禁用输入。

Enhancements:
- 改进每周问题的过渡体验，包括可访问的状态消息、焦点管理以及减少动效支持。

Tests:
- 更新 game-data、game-engine、API、web 和 friend-challenge 的测试覆盖，以适配修订后的 Currency Wars 池和协同效果可见性行为。
- 新增每周问题过渡检测的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct Currency Wars pool data and feedback privacy while making weekly question handoffs explicit and input-safe.

Bug Fixes:
- Remove Acheron from the official Currency Wars unit pool and update the offline mode pack to manifest version 1.1.1.
- Expose a guessed Currency Wars unit’s own synergy names while keeping shared-synergy matches anonymous.
- Add an explicit transition state between weekly questions and temporarily disable input while the next question loads.

Enhancements:
- Improve weekly question transitions with accessible status messaging, focus management, and reduced-motion support.

Tests:
- Update game-data, game-engine, API, web, and friend-challenge coverage for the revised Currency Wars pool and synergy visibility behavior.
- Add coverage for weekly question transition detection.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

校正 Currency Wars 池数据和反馈隐私，同时让每周问题的交接过程更明确并确保输入安全。

Bug Fixes:
- 将 Acheron 从官方的 Currency Wars 单位池中移除，并将离线模式包更新到 manifest 版本 1.1.1。
- 在保持共享协同效果匹配匿名的前提下，暴露被猜测的 Currency Wars 单位自身的协同效果名称。
- 在每周问题之间增加一个显式的过渡状态，并在下一个问题加载期间暂时禁用输入。

Enhancements:
- 改进每周问题的过渡体验，包括可访问的状态消息、焦点管理以及减少动效支持。

Tests:
- 更新 game-data、game-engine、API、web 和 friend-challenge 的测试覆盖，以适配修订后的 Currency Wars 池和协同效果可见性行为。
- 新增每周问题过渡检测的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct Currency Wars pool data and feedback privacy while making weekly question handoffs explicit and input-safe.

Bug Fixes:
- Remove Acheron from the official Currency Wars unit pool and update the offline mode pack to manifest version 1.1.1.
- Expose a guessed Currency Wars unit’s own synergy names while keeping shared-synergy matches anonymous.
- Add an explicit transition state between weekly questions and temporarily disable input while the next question loads.

Enhancements:
- Improve weekly question transitions with accessible status messaging, focus management, and reduced-motion support.

Tests:
- Update game-data, game-engine, API, web, and friend-challenge coverage for the revised Currency Wars pool and synergy visibility behavior.
- Add coverage for weekly question transition detection.

</details>

</details>