### PR TITLE
fix: stabilize mobile route and game scrolling

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, type ReactNode } from "react";
+import { lazy, Suspense, useEffect, useLayoutEffect, type ReactNode } from "react";
 import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { AppShell } from "../components/AppShell";
@@ -63,16 +63,6 @@ function ThemeAndLocaleSync() {
   return null;
 }
 
-function RouteScrollReset() {
-  const { pathname } = useLocation();
-
-  useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
-  }, [pathname]);
-
-  return null;
-}
-
 const defaultMode = getDefaultMode();
 
 function DefaultModeRedirect() {
@@ -116,6 +106,18 @@ function OnlineActivity({ children }: { children: ReactNode }) {
 
 function RouteContent() {
   const { pathname } = useLocation();
+
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    const previousScrollBehavior = root.style.scrollBehavior;
+    root.style.scrollBehavior = "auto";
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+
+    return () => {
+      root.style.scrollBehavior = previousScrollBehavior;
+    };
+  }, [pathname]);
+
   return (
     <div className="route-transition" key={pathname} data-route={pathname}>
       <Routes>
@@ -170,7 +172,6 @@ export function App() {
   return (
     <BrowserRouter>
       <ThemeAndLocaleSync />
-      <RouteScrollReset />
       <AppShell>
         <Suspense fallback={<LoadingScreen />}>
           <RouteContent />

--- a/apps/web/src/features/game/GamePage.tsx
+++ b/apps/web/src/features/game/GamePage.tsx
@@ -415,7 +415,7 @@ function ActiveGame({
     setChallengeError(false);
     setSharePreview(null);
     observedGuessCountRef.current = game.guesses.length;
-    gameHeadingRef.current?.focus();
+    gameHeadingRef.current?.focus({ preventScroll: true });
   }, [game.id]);
 
   useEffect(() => {
@@ -1013,7 +1013,11 @@ export function ModeGamePage({
 
   useEffect(() => {
     if (!game) return;
+    const root = document.documentElement;
+    const previousScrollBehavior = root.style.scrollBehavior;
+    root.style.scrollBehavior = "auto";
     window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    root.style.scrollBehavior = previousScrollBehavior;
   }, [game?.id]);
 
   const offlinePackBusy =

--- a/apps/web/src/features/game/RulesPanel.tsx
+++ b/apps/web/src/features/game/RulesPanel.tsx
@@ -42,10 +42,10 @@ export function RulesPanel({
 
   useEffect(() => {
     if (!open) {
-      triggerRef.current?.focus();
+      triggerRef.current?.focus({ preventScroll: true });
       return;
     }
-    dialogRef.current?.focus();
+    dialogRef.current?.focus({ preventScroll: true });
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false);
     };

--- a/apps/web/src/features/game/game.css
+++ b/apps/web/src/features/game/game.css
@@ -1743,7 +1743,9 @@
 
 .guess-board-scroll {
   overflow-x: auto;
+  overscroll-behavior-x: contain;
   padding-bottom: 10px;
+  -webkit-overflow-scrolling: touch;
 }
 .guess-board {
   width: 100%;
@@ -1916,6 +1918,20 @@
 .guess-row.is-latest .feedback-cell.direction-lower .feedback-icon {
   animation: direction-cue 320ms var(--motion-ease) both;
   animation-delay: calc(var(--cell-delay) + 250ms);
+}
+
+@media (max-width: 680px) {
+  /* 移动端让整张表一起横向滚动，避免 sticky 首列压住后续反馈格。 */
+  .guess-board-scroll {
+    max-width: 100%;
+    touch-action: pan-x pan-y;
+  }
+
+  .guess-board thead th:first-child,
+  .guess-board tbody th {
+    position: static;
+    box-shadow: none;
+  }
 }
 
 .board-empty {


### PR DESCRIPTION
## Summary\n- reset scroll position instantly on route changes\n- prevent game and rules focus restoration from moving the viewport\n- keep mobile guess boards horizontally scrollable without sticky-column overlap\n\n## Verification\n- un --cwd apps/web test -- src/features/game/GuessBoard.test.tsx\n- un --cwd apps/web typecheck\n- git diff --check\n- mobile browser audit at 360x780

## 由 Sourcery 提供的总结

在整个 Web 应用中稳定路由、游戏以及移动端猜词面板的滚动行为。

错误修复：
- 通过即时重置滚动并防止焦点恢复时滚动页面，在路由和游戏切换期间稳定视口位置。
- 改进移动端猜词面板的滚动表现，确保面板保持可水平滚动，同时避免与固定列出现重叠。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize route, game, and mobile guess-board scrolling behavior across the web application.

Bug Fixes:
- Stabilize viewport positioning during route and game transitions by resetting scroll instantly and preventing focus restoration from scrolling the page.
- Improve mobile guess-board scrolling by keeping the board horizontally scrollable without sticky-column overlap.

</details>